### PR TITLE
fixed lint problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,4 @@ lint-go:
 	golangci-lint run ./...
 
 lint-def:
-	docker run -it --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:latest lint definitions/swagger.yaml
+	docker run --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:latest lint definitions/swagger.yaml

--- a/Makefile
+++ b/Makefile
@@ -62,14 +62,15 @@ goimports: fmt
 fmt:
 	find . -name '*.go' | grep -v vendor | xargs gofmt -s -w
 
-.PHONY: lint
-lint:
-	golangci-lint run ./...
-
 .PHONY: set-license
 set-license:
 	@addlicense -c $(AUTHOR) -y $(COPYRIGHT_YEAR) $(COPYRIGHT_FILES)
 
-.PHONY: lint_definition
-lint_definition:
-	docker run -it --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:latest lint definitions/*.{json,yaml,yml}
+.PHONY: lint lint-go lint-def
+lint: lint-go lint-def
+
+lint-go:
+	golangci-lint run ./...
+
+lint-def:
+	docker run -it --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:latest lint definitions/swagger.yaml

--- a/definitions/swagger.yaml
+++ b/definitions/swagger.yaml
@@ -1474,8 +1474,7 @@ components:
       example: passw0rd
       minLength: 8
       maxLength: 32
-      pattern: |
-        [0-9a-zA-Z!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~]+
+      pattern: ^[0-9a-zA-Z!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~]+$
       description: |-
         英数字と記号の組み合わせ
         1文字以上のアルファベットと1文字以上の数字が必須
@@ -1719,9 +1718,10 @@ components:
               type: integer
               example: 8
             cpu_clock_speed:
-              type: string
+              type: number
+              format: float
               description: CPUクロック数(GHz)
-              example: '2.1'
+              example: 2.1
             memory_size:
               type: integer
               description: 総メモリ数(GB)
@@ -1771,7 +1771,7 @@ components:
                       * `ssd` - SSD
                       * `flash_memory` - Flash Memory(不揮発性メモリ)
                   device_count:
-                    type: string
+                    type: integer
                     description: ストレージ構成物理デバイス数
                     example: 2
             total_storage_device_count:
@@ -1934,7 +1934,7 @@ components:
           example: 100
           nullable: true
         local_bandwidth_mbps:
-          type: string
+          type: integer
           description: |-
             ローカル側の帯域幅(Mbps)
             ボンディングされている場合は合計値
@@ -2037,7 +2037,7 @@ components:
               type: string
               format: ipv4
               description: ブロードキャストアドレス
-              example: 192.0.239
+              example: 192.0.2.239
             special_use_addresses:
               type: array
               description: 特別な用途で割り当て済みのIPアドレスのリスト

--- a/zz_types_gen.go
+++ b/zz_types_gen.go
@@ -382,7 +382,7 @@ type InterfacePort struct {
 
 	// ローカル側の帯域幅(Mbps)
 	// ボンディングされている場合は合計値
-	LocalBandwidthMbps *string `json:"local_bandwidth_mbps"`
+	LocalBandwidthMbps *int `json:"local_bandwidth_mbps"`
 
 	// 動作モード(初期化後の未設定時は`null`)
 	Mode *InterfacePortMode `json:"mode"`
@@ -799,7 +799,7 @@ type Server struct {
 	Service *ServiceQuiet `json:"service,omitempty"`
 	Spec    *struct {
 		// CPUクロック数(GHz)
-		CpuClockSpeed *string `json:"cpu_clock_speed,omitempty"`
+		CpuClockSpeed *float32 `json:"cpu_clock_speed,omitempty"`
 
 		// 総CPUコア数
 		CpuCoreCount *int `json:"cpu_core_count,omitempty"`
@@ -830,7 +830,7 @@ type Server struct {
 			BusType *ServerSpecStoragesBusType `json:"bus_type,omitempty"`
 
 			// ストレージ構成物理デバイス数
-			DeviceCount *string `json:"device_count,omitempty"`
+			DeviceCount *int `json:"device_count,omitempty"`
 
 			// ストレージ記録方式
 			//


### PR DESCRIPTION
closes #7

- GitHub Actionsで定義ファイルのlintも実施する
- #7 の問題の修正

#### 修正の詳細(error)

- `password_input.example`

descriptionの`英数字と記号の組み合わせ/1文字以上のアルファベットと1文字以上の数字が必須`を表現しようとすると複雑になるため、前者+1文字以上を表す正規表現に修正

- `cpu_clock_speed`

数値型と思われるが、exampleからは浮動小数点数型に見受けられるため、floatに修正

- `server.properties.spec.properties.storages.items.properties.device_count.example`

データの性質上、自然数のみと思われるため`integer`に修正

- `interface_port.properties.local_bandwidth_mbps.example`

データの性質上、数値と思われる。floatにすべきか迷ったが、類似項目である`interface_port.properties.global_bandwidth_mbps.example`がintegerであるためそれに習っている。

- `dedicated_subnet.properties.ipv4.properties.broadcast_address.example`

ネットワークアドレスやサブネットマスク長から算出すると`192.0.2.239`が正しいと思われる。


💡 warningについては数が多いため別PRとする